### PR TITLE
Display existing notebooks on the new page

### DIFF
--- a/app/EditorPage.jsx
+++ b/app/EditorPage.jsx
@@ -156,7 +156,6 @@ export function EditorPage({id: initialId}) {
               <div key={notebook.id} className={cn("flex items-start flex-col gap-1")}>
                 <SafeLink
                   href={`/notebooks/${notebook.id}`}
-                  key={notebook.id}
                   className={cn(
                     "font-semibold hover:underline text-blue-500 whitespace-nowrap line-clamp-1 max-w-[150px] text-ellipsis",
                   )}


### PR DESCRIPTION
@jackbdu Jack mentioned that he wasn’t aware the notebook was saved after navigating away from the new page. To address this, I think it would be helpful to give users a hint that there’s a Notebooks page. 

Taking inspiration from [Github Gist](https://gist.github.com/), we can display a few existing notebooks directly on the new page as a subtle cue:

<img width="1529" height="871" alt="image" src="https://github.com/user-attachments/assets/a6d40ca6-5311-4082-bd86-cf811002a9b5" />

Here’s how the updated new page looks:

<img width="1529" height="874" alt="image" src="https://github.com/user-attachments/assets/bae34361-b3ec-4cb2-8d98-a09ac9d1b72c" />

And when there are no notebooks, it appears like this:

<img width="1530" height="874" alt="image" src="https://github.com/user-attachments/assets/675ce9c2-8820-46d1-969a-050084ab4f26" />


