### PR TITLE
Fix Vercel Analytics endpoint

### DIFF
--- a/app/layout.jsx
+++ b/app/layout.jsx
@@ -8,16 +8,24 @@ export const metadata = {
   description: "Recho Notebook - A interactive editor for algorithms and ASCII art",
 };
 
+const insightsEndpoint =
+  process.env.NEXT_PUBLIC_VERCEL_ANALYTICS_ENDPOINT ||
+  (process.env.VERCEL_ENV === "production" ? "https://recho-notebook.vercel.app/_vercel/insights" : undefined);
+
+const analyticsProps = insightsEndpoint
+  ? {
+      endpoint: insightsEndpoint,
+      scriptSrc: `${insightsEndpoint}/script.js`,
+    }
+  : {};
+
 export default function Layout({children}) {
   return (
     <html lang="en">
       <body className={cn("text-sm")}>
         <Nav />
         <main>{children}</main>
-        <Analytics
-          scriptSrc="https://recho-notebook.vercel.app/_vercel/insights/script.js"
-          endpoint="https://recho-notebook.vercel.app/_vercel/insights"
-        />
+        <Analytics {...analyticsProps} />
       </body>
     </html>
   );

--- a/app/layout.jsx
+++ b/app/layout.jsx
@@ -14,7 +14,10 @@ export default function Layout({children}) {
       <body className={cn("text-sm")}>
         <Nav />
         <main>{children}</main>
-        <Analytics />
+        <Analytics
+          scriptSrc="https://recho-notebook.vercel.app/_vercel/insights/script.js"
+          endpoint="https://recho-notebook.vercel.app/_vercel/insights"
+        />
       </body>
     </html>
   );

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,0 +1,6 @@
+packages:
+  - .
+
+allowBuilds:
+  esbuild: true
+  sharp: true


### PR DESCRIPTION
## Summary
- configure Vercel Analytics to load from the notebook project endpoint
- send analytics events to the notebook project when served from recho.dev/notebook
- allow pnpm-approved install scripts for esbuild and sharp so frozen installs pass in CI

## Verification
- npm run app:build
- CI=true npx pnpm@11.24.0 install --frozen-lockfile
- CI=true npx pnpm@11.24.0 test