### PR TITLE
Use same-origin Vercel Analytics

### DIFF
--- a/app/layout.jsx
+++ b/app/layout.jsx
@@ -8,24 +8,13 @@ export const metadata = {
   description: "Recho Notebook - A interactive editor for algorithms and ASCII art",
 };
 
-const insightsEndpoint =
-  process.env.NEXT_PUBLIC_VERCEL_ANALYTICS_ENDPOINT ||
-  (process.env.VERCEL_ENV === "production" ? "https://recho-notebook.vercel.app/_vercel/insights" : undefined);
-
-const analyticsProps = insightsEndpoint
-  ? {
-      endpoint: insightsEndpoint,
-      scriptSrc: `${insightsEndpoint}/script.js`,
-    }
-  : {};
-
 export default function Layout({children}) {
   return (
     <html lang="en">
       <body className={cn("text-sm")}>
         <Nav />
         <main>{children}</main>
-        <Analytics {...analyticsProps} />
+        <Analytics />
       </body>
     </html>
   );


### PR DESCRIPTION
## Summary
- remove the cross-origin Vercel Analytics endpoint override
- use the Vercel Analytics same-origin default now that the recho.dev insights script is available
- keep the pnpm build-script allowlist from the previous fix on main

## Why
The cross-origin endpoint at recho-notebook.vercel.app returns OK to curl, but its OPTIONS and POST responses do not include Access-Control-Allow-Origin. A real browser viewing recho.dev/notebook can therefore block the analytics beacon with CORS. Same-origin /_vercel/insights paths avoid that.

Also note that automated and headless browser checks do not increment Vercel Analytics because the Insights script exits when navigator.webdriver or a Headless user agent is detected.

## Verification
- CI=true npx pnpm@11.24.0 install --frozen-lockfile
- npm run app:build
- curl -I -L https://recho.dev/_vercel/insights/script.js returns 200