### PR TITLE
Prefix notebook analytics paths

### DIFF
--- a/app/NotebookAnalytics.jsx
+++ b/app/NotebookAnalytics.jsx
@@ -1,0 +1,17 @@
+"use client";
+
+import {Analytics} from "@vercel/analytics/next";
+import {BASE_PATH} from "./shared.js";
+
+function prefixNotebookPath(event) {
+  const url = new URL(event.url);
+  if (url.pathname === BASE_PATH || url.pathname.startsWith(`${BASE_PATH}/`)) {
+    return event;
+  }
+  url.pathname = `${BASE_PATH}${url.pathname === "/" ? "" : url.pathname}`;
+  return {...event, url: url.toString()};
+}
+
+export function NotebookAnalytics() {
+  return <Analytics beforeSend={prefixNotebookPath} />;
+}

--- a/app/layout.jsx
+++ b/app/layout.jsx
@@ -1,7 +1,7 @@
 import "./global.css";
 import {Nav} from "./Nav.jsx";
 import {cn} from "./cn.js";
-import {Analytics} from "@vercel/analytics/next";
+import {NotebookAnalytics} from "./NotebookAnalytics.jsx";
 
 export const metadata = {
   title: "Recho Notebook",
@@ -14,7 +14,7 @@ export default function Layout({children}) {
       <body className={cn("text-sm")}>
         <Nav />
         <main>{children}</main>
-        <Analytics />
+        <NotebookAnalytics />
       </body>
     </html>
   );


### PR DESCRIPTION
## Summary
- wrap Vercel Analytics in a client component
- use beforeSend to restore the /notebook prefix in reported page URLs
- keep analytics collection same-origin to avoid CORS issues

## Why
Next usePathname reports paths without the app basePath, so Vercel Analytics shows notebook pages as /docs, /examples, and /works under recho.dev. This keeps the working same-origin /_vercel/insights collection path but records page URLs as /notebook/docs, /notebook/examples, and /notebook/works.

## Verification
- npx pnpm@11.24.0 exec prettier --check app/layout.jsx app/NotebookAnalytics.jsx
- npm run app:build