### PR TITLE
Rebrand "Recho Notebook" to "Recho"

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,6 +1,6 @@
-# Recho Notebook - Contributing
+# Recho - Contributing
 
-Recho Notebook is open source and released under the [ISC license](/LICENCE). You are welcome to contribute in different ways: open a [pull request](https://github.com/recho-dev/notebook/pulls), participate in [issues](https://github.com/recho-dev/notebook/issues) and [discussions](https://github.com/recho-dev/notebook/discussions) or star this project!
+Recho is open source and released under the [ISC license](/LICENCE). You are welcome to contribute in different ways: open a [pull request](https://github.com/recho-dev/notebook/pulls), participate in [issues](https://github.com/recho-dev/notebook/issues) and [discussions](https://github.com/recho-dev/notebook/discussions) or star this project!
 
 ## Sharing Examples
 

--- a/README.md
+++ b/README.md
@@ -1,21 +1,21 @@
-# Recho Notebook
+# Recho
 
 ![preview](./img/preview.png)
 
 > We want to live in the editor forever. — [Luyu Cheng](https://luyu.computer/)
 
-[**Recho Notebook**](https://recho.dev/notebook) is a free, [open-source](/LICENCE), reactive editor for algorithms and ASCII art. It introduces a _plain code format_ for notebooks — echoing output inline as comments for live, in-situ coding with instant feedback. Built on vanilla JavaScript and the reactive model of [Observable Notebook Kit](https://observablehq.com/notebook-kit/), Recho Notebook lets developers, artists, and learners explore algorithms and ASCII art interactively.
+[**Recho**](https://recho.dev/notebook) is a free, [open-source](/LICENCE), reactive editor for algorithms and ASCII art. It introduces a _plain code format_ for notebooks — echoing output inline as comments for live, in-situ coding with instant feedback. Built on vanilla JavaScript and the reactive model of [Observable Notebook Kit](https://observablehq.com/notebook-kit/), Recho lets developers, artists, and learners explore algorithms and ASCII art interactively.
 
-- [Editor](https://recho.dev/notebook) 📝 - The quickest way to get started with Recho Notebook.
-- [Announcement](https://medium.com/@subairui/a-lighter-way-to-code-with-creativity-8c0ac739aa6f) 📢 - Read our initial release story to discovery the vision behind Recho Notebook.
-- [Documentation](https://recho.dev/notebook/docs/introduction) 📚 - Learn how to use Recho Notebook with our comprehensive guides.
+- [Editor](https://recho.dev/notebook) 📝 - The quickest way to get started with Recho.
+- [Announcement](https://medium.com/@subairui/a-lighter-way-to-code-with-creativity-8c0ac739aa6f) 📢 - Read our initial release story to discovery the vision behind Recho.
+- [Documentation](https://recho.dev/notebook/docs/introduction) 📚 - Learn how to use Recho with our comprehensive guides.
 - [Examples](https://recho.dev/notebook/examples) 🖼️ - See what you can create and draw some inspiration!
 - [Sharing](/CONTRIBUTING.md#sharing-examples) 🎨 - Follow the instructions to open a [pull request](https://github.com/recho-dev/notebook/new/main/app/examples) to share your sketches!
 - [Contributing](/CONTRIBUTING.md) 🙏 - We have [a bunch of things](https://github.com/recho-dev/notebook/issues) that we would like you to help us build together!
 
 ## Core Idea 🧠
 
-Unlike typical notebooks (like Jupyter or Observable), Recho Notebook treats **code and its output as a single, continuous document**. When you write code, **the output appears inline — as a comment right above your code**.
+Unlike typical notebooks (like Jupyter or Observable), Recho treats **code and its output as a single, continuous document**. When you write code, **the output appears inline — as a comment right above your code**.
 
 ![A Quick Example](./img/dog.gif)
 
@@ -25,7 +25,7 @@ If you modify the code, the echoed output updates immediately. So instead of swi
 
 The name **Recho** comes from “Reactive Echo” — every expression echoes its result, instantly. It’s meant to capture the feedback loop between code and creator — seeing how every small change ripples through your work.
 
-Recho Notebook is both a tool and a statement — it imagines what happens if we strip away complex GUIs and treat code itself as the canvas.
+Recho is both a tool and a statement — it imagines what happens if we strip away complex GUIs and treat code itself as the canvas.
 
 It’s light, artistic, and reactive — blending ideas from creative coding, literate programming, and live performance.
 
@@ -35,20 +35,20 @@ It’s light, artistic, and reactive — blending ideas from creative coding, li
 - Creating text-based animations to experience the simplicity and clarity in ASCII art.
 - Exploring code minimalism — finding beauty in code and its textual output.
 
-## Why Recho Notebook 🪶
+## Why Recho 🪶
 
 We’ve always loved [Observable Notebooks](https://observablehq.com/). To make notebooks more portable, we built [Markdown Genji](https://genji-md.dev/), extending Markdown with live code features. Later, [Observable Framework](https://observablehq.com/framework) and [Observable Notebook Kit](https://observablehq.com/notebook-kit/) explored similar ideas, which made us wonder — could a notebook exist as a plain code file?
 
 At the same time, we wanted to make coding more accessible and playful. Inspired by the [p5.js web editor](https://editor.p5js.org/), we realized **well-designed language doesn’t necessarily make coding more accessible — the environment does**. So we asked — what if we focused on algorithms instead of graphics, using ASCII art when visuals are needed?
 
-That’s how Recho Notebook began — **[a lighter way to code with creativity](https://medium.com/@subairui/a-lighter-way-to-code-with-creativity-8c0ac739aa6f)**.
+That’s how Recho began — **[a lighter way to code with creativity](https://medium.com/@subairui/a-lighter-way-to-code-with-creativity-8c0ac739aa6f)**.
 
 ## What's Next 🔥
 
-Recho Notebook is in beta — and open source! 🎉 Try it out on our [website](https://recho.dev/notebook) or explore the code on [GitHub](https://github.com/recho-dev/notebook). We’d love your thoughts, comments, or suggestions. Want to contribute? Here’s where you can help:
+Recho is in beta — and open source! 🎉 Try it out on our [website](https://recho.dev/notebook) or explore the code on [GitHub](https://github.com/recho-dev/notebook). We’d love your thoughts, comments, or suggestions. Want to contribute? Here’s where you can help:
 
 - **Sharing Examples** – [text analysis](https://recho.dev/notebook/examples/word-count), [ASCII art](https://recho.dev/notebook/examples/moon-sundial), [data viz](https://recho.dev/notebook/examples/phases-of-the-moon), [graphics](https://recho.dev/notebook/examples/cg-text-based-shaders), [concrete poetry](https://recho.dev/notebook/examples/fire!), or demos with [D3](https://d3js.org/), [Tone](https://tonejs.github.io/), [ml5](https://ml5js.org/)… anything! One example is enough.
-- **Polyglot Programming** – Recho Notebook is JavaScript-first but open to any language that compiles to JavaScript — [Python](https://www.python.org/), [Rust](https://www.rust-lang.org/), [MLscript](https://github.com/hkust-taco/mlscript), [wenyan‑lang](https://wy-lang.org/)… your playground.
+- **Polyglot Programming** – Recho is JavaScript-first but open to any language that compiles to JavaScript — [Python](https://www.python.org/), [Rust](https://www.rust-lang.org/), [MLscript](https://github.com/hkust-taco/mlscript), [wenyan‑lang](https://wy-lang.org/)… your playground.
 - **LLM Experiments** – What if LLMs could "see" both the input and the output?
 
 We’re also improving:
@@ -61,4 +61,4 @@ Cloud storage is coming, but for now, keep it simple — and keep the ideas comi
 
 ## License 📄
 
-ISC © [Recho Notebook](https://github.com/recho-dev)
+ISC © [Recho](https://github.com/recho-dev)

--- a/app/EditorPage.jsx
+++ b/app/EditorPage.jsx
@@ -59,7 +59,7 @@ export function EditorPage({id: initialId}) {
   useEffect(() => {
     // Use setTimeout to avoid changing to default title.
     setTimeout(() => {
-      document.title = `${isAdded ? notebook.title : "New"} | Recho Notebook`;
+      document.title = `${isAdded ? notebook.title : "New"} | Recho`;
     }, 100);
   }, [notebook, isAdded]);
 

--- a/app/Nav.jsx
+++ b/app/Nav.jsx
@@ -51,11 +51,8 @@ export function Nav() {
   return (
     <header className={cn("flex justify-between items-center p-4 border-b border-gray-200")}>
       <div className={cn("flex md:gap-2 items-center ")}>
-        <a href="https://recho.dev" target="_blank" rel="noopener noreferrer">
-          <h1 className={cn("text-xl font-extrabold")}>Recho</h1>
-        </a>
         <SafeLink href="/">
-          <h1 className={cn("text-xl hidden md:inline font-medium")}>Notebook</h1>
+          <h1 className={cn("text-xl font-extrabold")}>Recho</h1>
         </SafeLink>
         {/* Desktop navigation */}
         <div className={cn("hidden md:flex gap-2 items-center")}>

--- a/app/api.js
+++ b/app/api.js
@@ -14,14 +14,14 @@ function generateProjectName() {
 }
 
 const DEFAULT_CONTENT = `
-/* 
-** Welcome to                                                                         
-**  ___        _          _  _     _       _              _   
-** | _ \\___ __| |_  ___  | \\| |___| |_ ___| |__  ___  ___| |__
-** |   / -_) _| ' \\/ _ \\ | .\` / _ \\  _/ -_) '_ \\/ _ \\/ _ \\ / /
-** |_|_\\___\\__|_||_\\___/ |_|\\_\\___/\\__\\___|_.__/\\___/\\___/_\\_\\
+/*
+** Welcome to
+**  ___        _
+** | _ \\___ __| |_  ___
+** |   / -_) _| ' \\/ _ \\
+** |_|_\\___\\__|_||_\\___/
 **
-** A reactive editor for algorithms and ASCII art. 
+** A reactive editor for algorithms and ASCII art.
 */
 
 // 1. You can call echo(value) to echo output inline as comments, which allows
@@ -48,7 +48,7 @@ const x1 = recho.number(10, {min: 0, max: 40, step: 1});
 //➜ "(๑•̀ㅂ•́)و✧"
 echo("~".repeat(x1) + "(๑•̀ㅂ•́)و✧");
 
-// Refer to the links (cmd/ctrl + click) to learn more about Recho Notebook:
+// Refer to the links (cmd/ctrl + click) to learn more about Recho:
 // - Docs: https://recho.dev/notebook/docs
 // - Examples: https://recho.dev/notebook/examples
 // - Github: https://github.com/recho-dev/notebook

--- a/app/docs/[slug]/page.jsx
+++ b/app/docs/[slug]/page.jsx
@@ -12,7 +12,7 @@ export async function generateMetadata({params}) {
   const doc = getAllJSDocs().find((doc) => doc.slug === slug);
   if (!doc) notFound();
   return {
-    title: `${doc.title} | Recho Notebook`,
+    title: `${doc.title} | Recho`,
   };
 }
 

--- a/app/docs/animations-authoring.recho.js
+++ b/app/docs/animations-authoring.recho.js
@@ -8,8 +8,8 @@
  * ============================================================================
  *
  * Animations are very powerful tools making your notebooks more interactive
- * and engaging. In Recho Notebook, there are at least two ways to author 
- * animations. You can choose either one which suits you best.
+ * and engaging. In Recho, there are at least two ways to author animations.
+ * You can choose either one which suits you best.
  *
  * ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
  *                          Block-level Animations

--- a/app/docs/api-reference.recho.js
+++ b/app/docs/api-reference.recho.js
@@ -7,9 +7,9 @@
  * =                            API Reference                                =
  * ============================================================================
  *
- * Recho Notebook provides a set of APIs to help you create reactive notebooks
- * and interactive visualizations. This page provides an overview of all
- * available APIs.
+ * Recho provides a set of APIs to help you create reactive notebooks and
+ * interactive visualizations. This page provides an overview of all available
+ * APIs.
  *
  * Click on any API below to see detailed documentation and examples.
  *

--- a/app/docs/aynchronous-operations.recho.js
+++ b/app/docs/aynchronous-operations.recho.js
@@ -11,7 +11,7 @@
  * an API, importing external packages, or waiting for a user action. These
  * operations can be represented as promises[1] in JavaScript.
  *
- * In Recho Notebook, top-level await is supported.
+ * In Recho, top-level await is supported.
  */
 
 const string = await new Promise((resolve) => setTimeout(() => resolve("I'm a string!"), 1000));
@@ -51,8 +51,8 @@ echo(string2);
 }
 
 /**
- * In Recho Notebook, you will typically use promises to import external packages.
- * Refer to https://recho.dev/docs/libraries-imports for more details.
+ * In Recho, you will typically use promises to import external packages. Refer
+ * to https://recho.dev/docs/libraries-imports for more details.
  */
 
 const d3 = recho.require("d3");

--- a/app/docs/getting-started.recho.js
+++ b/app/docs/getting-started.recho.js
@@ -7,16 +7,16 @@
  * =                            Getting Started                               =
  * ============================================================================
  *
- * This page will quickly guide you through the core concepts of Recho Notebook.
- * After reading this, you will be able to create your own notebooks!
+ * This page will quickly guide you through the core concepts of Recho. After
+ * reading this, you will be able to create your own notebooks!
  *
  * ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
  *                              Inline Echoing
  * ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
  *
- * Recho Notebook allows you to echo output inline with your code. This is
- * useful for quickly inspecting your variables and display the output as
- * comments. Each line of output is prefixed with `//➜`.
+ * Recho allows you to echo output inline with your code. This is useful for
+ * quickly inspecting your variables and display the output as comments. Each
+ * line of output is prefixed with `//➜`.
  *
  * To echo output, you can use the `echo` function:
  */
@@ -55,9 +55,9 @@ const foo = echo(function add(a, b) {
  *                             Reactive Blocks
  * ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
  *
- * Blocks are the fundamentals of Recho Notebook's reactive system. Each
- * top-level statement is a block. The output always appears above the block.
- * Once the upstream blocks change, the downstream blocks will be re-evaluated.
+ * Blocks are the fundamentals of Recho's reactive system. Each top-level
+ * statement is a block. The output always appears above the block. Once the
+ * upstream blocks change, the downstream blocks will be re-evaluated.
  *
  * For example, if you update the value of `a`, then click the run button, `b`
  * will be re-evaluated.
@@ -83,8 +83,8 @@ const b = echo(a + 1);
 }
 
 /**
- * Unlike vanilla JavaScript, you can define blocks in any order. Recho
- * Notebook will automatically execute the blocks in the correct order.
+ * Unlike vanilla JavaScript, you can define blocks in any order. Recho will
+ * automatically execute the blocks in the correct order.
  */
 
 //➜ "I'll be executed first!"
@@ -101,9 +101,9 @@ const c = "I'll be executed first!";
  *                             Animations Authoring
  * ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
  *
- * Recho Notebook provides two built-in functions to create fluid animations.
- * The first one is `recho.now()`, which returns a generator that yields the
- * current time continuously.
+ * Recho provides two built-in functions to create fluid animations. The first
+ * one is `recho.now()`, which returns a generator that yields the current time
+ * continuously.
  */
 
 const now = recho.now();
@@ -140,10 +140,9 @@ echo(counter);
  *                         Interactive Input Controls
  * ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
  *
- * Recho Notebook provides interactive input controls that allow users to
- * modify values directly in the editor. These controls update the code as
- * users interact with them, making it easy to explore different parameter
- * values.
+ * Recho provides interactive input controls that allow users to modify values
+ * directly in the editor. These controls update the code as users interact
+ * with them, making it easy to explore different parameter values.
  *
  * The `recho.toggle` function creates a checkbox control for boolean values:
  */
@@ -178,9 +177,8 @@ const rating = recho.number(5, {min: 1, max: 10, step: 0.5});
 }
 
 /**
- * These controls work seamlessly with Recho Notebook's reactive system. When
- * you change a control value, all dependent blocks are automatically
- * re-evaluated:
+ * These controls work seamlessly with Recho's reactive system. When you change
+ * a control value, all dependent blocks are automatically re-evaluated:
  */
 
 const size = recho.number(3, {min: 1, max: 8});
@@ -207,7 +205,7 @@ const size = recho.number(3, {min: 1, max: 8});
  * There are some asynchronous operations that you need to handle, such as
  * fetching data from an API, requiring external packages, or waiting for a
  * user action. These operations can be represented as promises in JavaScript.
- * In Recho Notebook, top-level await is supported.
+ * In Recho, top-level await is supported.
  */
 
 const string = await new Promise((resolve) => setTimeout(() => resolve("I'm a string!"), 1000));
@@ -234,9 +232,9 @@ const sum = echo(numbers.reduce((a, b) => a + scale * b, 0));
  *                           Libraries Imports
  * ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
  *
- * Recho Notebook allows you to import external browser-based libraries using
- * the `recho.require` function. The import specifiers must be valid npm
- * package names with optional version specifiers.
+ * Recho allows you to import external browser-based libraries using the
+ * `recho.require` function. The import specifiers must be valid npm package
+ * names with optional version specifiers.
  *
  * For example, let's import the `d3` package:
  */
@@ -275,15 +273,13 @@ echo(d3.range(10));
  *  \____\___/|_| |_|\__, |_|  \__,_|\__|\__,_|_|\__,_|\__|_|\___/|_| |_|___/
  *                   |___/
  *
- * You've already mastered the basics of Recho Notebook! We highly recommend
- * you to go to the editor: https://recho.dev and start creating your own
- * notebooks!
+ * You've already mastered the basics of Recho! We highly recommend you to go
+ * to the editor: https://recho.dev and start creating your own notebooks!
  *
  * If you need inspiration, you can check out the examples page:
- * https://recho.dev/examples to see what you can create with Recho Notebook.
+ * https://recho.dev/examples to see what you can create with Recho.
  *
- * Of course, we'll not stop you if you want to dive into the details of Recho
- * Notebook.
+ * Of course, we'll not stop you if you want to dive into the details of Recho.
  *
  * Hackers and painters, let's paint by code!
  */

--- a/app/docs/inline-echoing.recho.js
+++ b/app/docs/inline-echoing.recho.js
@@ -7,7 +7,7 @@
  * =                            Inline Echoing                                =
  * ============================================================================
  *
- * The core feature of Recho Notebook is to echo output inline with your code as
+ * The core feature of Recho is to echo output inline with your code as
  * comments. Each line of the output is prefixed with `//➜`. You can call the
  * built-in function `echo` to echo output.
  */

--- a/app/docs/introduction.recho.js
+++ b/app/docs/introduction.recho.js
@@ -3,16 +3,16 @@
  */
 
 /**
- *            __        __   _                            _
- *            \ \      / /__| | ___ ___  _ __ ___   ___  | |_ ___
- *             \ \ /\ / / _ \ |/ __/ _ \| '_ ` _ \ / _ \ | __/ _ \
- *              \ V  V /  __/ | (_| (_) | | | | | |  __/ | || (_) |
- *               \_/\_/ \___|_|\___\___/|_| |_| |_|\___|  \__\___/
- *   ____           _             _   _       _       _                 _
- *  |  _ \ ___  ___| |__   ___   | \ | | ___ | |_ ___| |__   ___   ___ | | __
- *  | |_) / _ \/ __| '_ \ / _ \  |  \| |/ _ \| __/ _ \ '_ \ / _ \ / _ \| |/ /
- *  |  _ <  __/ (__| | | | (_) | | |\  | (_) | ||  __/ |_) | (_) | (_) |   <
- *  |_| \_\___|\___|_| |_|\___/  |_| \_|\___/ \__\___|_.__/ \___/ \___/|_|\_\
+ *  __        __   _                            _
+ *  \ \      / /__| | ___ ___  _ __ ___   ___  | |_ ___
+ *   \ \ /\ / / _ \ |/ __/ _ \| '_ ` _ \ / _ \ | __/ _ \
+ *    \ V  V /  __/ | (_| (_) | | | | | |  __/ | || (_) |
+ *     \_/\_/ \___|_|\___\___/|_| |_| |_|\___|  \__\___/
+ *   ____           _
+ *  |  _ \ ___  ___| |__   ___
+ *  | |_) / _ \/ __| '_ \ / _ \
+ *  |  _ <  __/ (__| | | | (_) |
+ *  |_| \_\___|\___|_| |_|\___/
  *
  * ============================================================================
  * =                            Introduction                                  =
@@ -20,14 +20,13 @@
  *
  * > We want to live in the editor forever. — Luyu Cheng[1]
  *
- * Recho Notebook[2] is a free, open-source, reactive editor for algorithms
- * and ASCII art. It introduces a plain code format for notebooks — echoing
- * output inline as comments for live, in-situ coding with instant feedback.
- * Built on vanilla JavaScript and the reactive model of Observable Notebook
- * Kit[3], Recho Notebook lets developers, artists, and learners explore and
- * create directly in code.
+ * Recho[2] is a free, open-source, reactive editor for algorithms and ASCII
+ * art. It introduces a plain code format for notebooks — echoing output inline
+ * as comments for live, in-situ coding with instant feedback. Built on vanilla
+ * JavaScript and the reactive model of Observable Notebook Kit[3], Recho lets
+ * developers, artists, and learners explore and create directly in code.
  *
- * Here is a word counting example to show the core feature of Recho Notebook:
+ * Here is a word counting example to show the core feature of Recho:
  * echoing output inline as comments. By calling `echo(results)`, the results
  * are displayed as comments above the statement! Now we can better understand
  * this piece of code by better "seeing" every manipulation. Notice that there

--- a/app/docs/layout.jsx
+++ b/app/docs/layout.jsx
@@ -3,8 +3,8 @@ import {DocsLayoutClient} from "./DocsLayoutClient.jsx";
 import {docsNavConfig} from "./nav.config.js";
 
 export const metadata = {
-  title: "Docs | Recho Notebook",
-  description: "Docs | Recho Notebook",
+  title: "Docs | Recho",
+  description: "Docs | Recho",
 };
 
 export default function Layout({children}) {

--- a/app/docs/libraries-imports.recho.js
+++ b/app/docs/libraries-imports.recho.js
@@ -7,8 +7,8 @@
  *                           Libraries Imports
  * ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
  *
- * Recho Notebook has some built-in libraries that you can access directly
- * through the namespace `recho`. There is no extra setup needed.
+ * Recho has some built-in libraries that you can access directly through the
+ * namespace `recho`. There is no extra setup needed.
  */
 
 const now = recho.now();
@@ -19,8 +19,8 @@ echo(now);
 /**
  * Refer to https://recho.dev/docs/api-reference for more built-in libraries.
  *
- * For using external libraries, Recho Notebook stdlib provides the
- * `recho.require` function to import one or more JavaScript packages.
+ * For using external libraries, Recho stdlib provides the `recho.require`
+ * function to import one or more JavaScript packages.
  *
  * For example, let's import the `d3-time` package to count the number of days
  * between two dates.

--- a/app/docs/reactive-blocks.recho.js
+++ b/app/docs/reactive-blocks.recho.js
@@ -7,8 +7,8 @@
  * =                            Reactive Blocks                               =
  * ============================================================================
  *
- * Reactive blocks are the fundamentals of Recho Notebook's reactive system,
- * which is built on the reactive model of Observable Notebook Kit[1].
+ * Reactive blocks are the fundamentals of Recho's reactive system, which is
+ * built on the reactive model of Observable Notebook Kit[1].
  *
  * ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
  *                            Top-level Statements
@@ -49,7 +49,7 @@ else echo("Odd");
 
 /**
  * !! NOTE: This can also avoid using `let` to define top-level mutable      !!
- * !! variables, which is not allowed in Recho Notebook yet.                 !!
+ * !! variables, which is not allowed in Recho yet.                          !!
  *
  * If you need to define a non-echoing top-level mutable variable, you can use
  * IIFE (Immediately Invoked Function Expression) to create a block and return
@@ -71,9 +71,9 @@ echo(alphabet);
  * ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
  *
  * All the blocks run automatically like running a vanilla JavaScript script.
- * The difference is that blocks in Recho Notebook run in topological order
- * determined by top-level variable references (a.k.a. **dataflow**), rather
- * than the top-down document order[2].
+ * The difference is that blocks in Recho run in topological order determined
+ * by top-level variable references (a.k.a. **dataflow**), rather than the
+ * top-down document order[2].
  *
  * For example, we have three blocks: `sum`, `a`, and `b` in top-down order.
  * Since `sum` depends on `a` and `b`, it will be evaluated after `a` and `b`.

--- a/app/examples/[slug]/page.jsx
+++ b/app/examples/[slug]/page.jsx
@@ -13,7 +13,7 @@ export async function generateMetadata({params}) {
   const example = getAllJSExamples().find((example) => example.slug === slug);
   if (!example) notFound();
   return {
-    title: `${example.title} | Recho Notebook`,
+    title: `${example.title} | Recho`,
   };
 }
 

--- a/app/examples/number-input.recho.js
+++ b/app/examples/number-input.recho.js
@@ -1,5 +1,5 @@
 /**
- * @title Recho Notebook's Number Input Control
+ * @title Recho's Number Input Control
  * @author Luyu Cheng
  * @created 2025-09-29
  * @pull_request 134
@@ -10,7 +10,7 @@
 
 /**
  * ============================================================================
- * =            Recho Notebook's Interactive Number Input Control            =
+ * =                 Recho's Interactive Number Input Control                 =
  * ============================================================================
  */
 

--- a/app/examples/page.jsx
+++ b/app/examples/page.jsx
@@ -5,8 +5,8 @@ import {LabelFilters} from "./LabelFilters.jsx";
 import {ExamplesClient} from "./ExamplesClient.jsx";
 
 export const metadata = {
-  title: "Examples | Recho Notebook",
-  description: "Examples | Recho Notebook",
+  title: "Examples | Recho",
+  description: "Examples | Recho",
 };
 
 // Cache examples at module level - Node.js module cache ensures this only runs once per process

--- a/app/layout.jsx
+++ b/app/layout.jsx
@@ -4,8 +4,8 @@ import {cn} from "./cn.js";
 import {Analytics} from "@vercel/analytics/next";
 
 export const metadata = {
-  title: "Recho Notebook",
-  description: "Recho Notebook - A interactive editor for algorithms and ASCII art",
+  title: "Recho",
+  description: "Recho - A interactive editor for algorithms and ASCII art",
 };
 
 export default function Layout({children}) {

--- a/app/works/page.jsx
+++ b/app/works/page.jsx
@@ -17,7 +17,7 @@ export default function Page() {
   }, []);
 
   useEffect(() => {
-    document.title = "Notebooks | Recho Notebook";
+    document.title = "Notebooks | Recho";
   }, []);
 
   function onDelete(id) {

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "recho-notebook",
+  "name": "recho",
   "version": "0.2.0",
   "description": "A free, open-source, reactive editor for algorithms and ASCII art. It introduces a plain code format for notebooks — echoing output inline as comments for live, in-situ coding with instant feedback.",
   "author": "Recho",


### PR DESCRIPTION
## Summary
- Replaces every occurrence of "Recho Notebook" with "Recho" across the README, CONTRIBUTING, page titles/metadata, and doc/example prose (`app/docs/*.recho.js`, `app/examples/*.recho.js`).
- Renames `package.json`'s `"name"` from `recho-notebook` to `recho`.
- Regenerates the two ASCII-art banners that spelled out "Recho Notebook" in figlet block letters (`app/api.js` default notebook boilerplate, `app/docs/introduction.recho.js`) to spell "Recho" instead, using the same fonts.
- Updates the nav logo (`app/Nav.jsx`): drops the separate "Notebook" label and makes the "Recho" logo link to the in-app editor (`/`) instead of the external `recho.dev` landing page.
- Reflows doc-comment paragraphs that were left ragged by the shorter brand name so every line fills back out to the file's usual width.

## Deliberately left unchanged
- `package.json` `homepage`/`repository`/`bugs` URLs and every `recho.dev/notebook` / `github.com/recho-dev/notebook` link — these point to real, existing infra (site route, GitHub repo), not brand copy, so editing the text wouldn't actually rename them.

## Test plan
- `npx prettier --check` on every edited file — passes.
- Full case-insensitive repo grep for `recho notebook` / `recho-notebook` / `rechonotebook` — zero remaining hits outside the untouched URLs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)