### PR TITLE
Serve app at / instead of /notebook, add redirects

### DIFF
--- a/app/api.js
+++ b/app/api.js
@@ -49,8 +49,8 @@ const x1 = recho.number(10, {min: 0, max: 40, step: 1});
 echo("~".repeat(x1) + "(๑•̀ㅂ•́)و✧");
 
 // Refer to the links (cmd/ctrl + click) to learn more about Recho:
-// - Docs: https://recho.dev/notebook/docs
-// - Examples: https://recho.dev/notebook/examples
+// - Docs: https://recho.dev/docs
+// - Examples: https://recho.dev/examples
 // - Github: https://github.com/recho-dev/notebook
 `;
 

--- a/app/docs/api-reference.recho.js
+++ b/app/docs/api-reference.recho.js
@@ -17,29 +17,29 @@
  *                                Core APIs
  * ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
  *
- * - echo(...values) - Echo values inline with your code as comments (https://recho.dev/notebook/docs/api-echo)
- * - echo.clear() - Clear the output of the current block (https://recho.dev/notebook/docs/api-echo-clear)
- * - echo.key(key) - Specify a key for the following output values (https://recho.dev/notebook/docs/api-echo-key)
- * - echo.dispose(callback) - Register a disposal callback before re-running the current block (https://recho.dev/notebook/docs/api-echo-dispose)
- * - recho.state(value) - Create reactive state variables for mutable values (https://recho.dev/notebook/docs/api-state)
- * - recho.inspect(value[, options]) - Format values for inspection (https://recho.dev/notebook/docs/api-inspect)
+ * - echo(...values) - Echo values inline with your code as comments (https://recho.dev/docs/api-echo)
+ * - echo.clear() - Clear the output of the current block (https://recho.dev/docs/api-echo-clear)
+ * - echo.key(key) - Specify a key for the following output values (https://recho.dev/docs/api-echo-key)
+ * - echo.dispose(callback) - Register a disposal callback before re-running the current block (https://recho.dev/docs/api-echo-dispose)
+ * - recho.state(value) - Create reactive state variables for mutable values (https://recho.dev/docs/api-state)
+ * - recho.inspect(value[, options]) - Format values for inspection (https://recho.dev/docs/api-inspect)
  *
  * ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
  *                                 Inputs
  * ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
- * - recho.toggle(value) - Interactive toggle (checkbox) control (https://recho.dev/notebook/docs/api-toggle)
- * - recho.radio(index, options) - Interactive radio button group (https://recho.dev/notebook/docs/api-radio)
- * - recho.number(value[, options]) - Interactive number input control (https://recho.dev/notebook/docs/api-number)
- * - recho.button(label[, id], callback) - Interactive button control (https://recho.dev/notebook/docs/api-button)
+ * - recho.toggle(value) - Interactive toggle (checkbox) control (https://recho.dev/docs/api-toggle)
+ * - recho.radio(index, options) - Interactive radio button group (https://recho.dev/docs/api-radio)
+ * - recho.number(value[, options]) - Interactive number input control (https://recho.dev/docs/api-number)
+ * - recho.button(label[, id], callback) - Interactive button control (https://recho.dev/docs/api-button)
  *
  * ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
  *                               Generators
  * ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
- * - recho.now() - Generator that yields the current time continuously (https://recho.dev/notebook/docs/api-now)
- * - recho.interval(milliseconds) - Generator that yields values at intervals (https://recho.dev/notebook/docs/api-interval)
+ * - recho.now() - Generator that yields the current time continuously (https://recho.dev/docs/api-now)
+ * - recho.interval(milliseconds) - Generator that yields values at intervals (https://recho.dev/docs/api-interval)
  *
  * ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
  *                                Helpers
  * ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
- * - recho.require(...names) - Import JavaScript packages from npm (https://recho.dev/notebook/docs/api-require)
+ * - recho.require(...names) - Import JavaScript packages from npm (https://recho.dev/docs/api-require)
  */

--- a/app/examples/ExamplesClient.jsx
+++ b/app/examples/ExamplesClient.jsx
@@ -5,6 +5,7 @@ import {useSearchParams} from "next/navigation";
 import {Meta} from "../Meta.js";
 import {ThumbnailClient} from "../ThumbnailClient.js";
 import {cn} from "../cn.js";
+import {BASE_PATH} from "../shared.js";
 
 export function ExamplesClient({examples}) {
   const searchParams = useSearchParams();
@@ -41,7 +42,7 @@ export function ExamplesClient({examples}) {
               {example.snap ? (
                 <div
                   className={cn("w-full h-full bg-cover bg-center")}
-                  style={{backgroundImage: `url(/notebook/examples/${example.snap})`}}
+                  style={{backgroundImage: `url(${BASE_PATH}/examples/${example.snap})`}}
                 />
               ) : (
                 <ThumbnailClient code={example.content} outputStartLine={example.outputStartLine} />

--- a/app/layout.jsx
+++ b/app/layout.jsx
@@ -15,9 +15,9 @@ export default function Layout({children}) {
         <Nav />
         <main>{children}</main>
         <Analytics
-          scriptSrc="/notebook/_vercel/insights/script.js"
-          viewEndpoint="/notebook/_vercel/insights/view"
-          eventEndpoint="/notebook/_vercel/insights/event"
+          scriptSrc="/_vercel/insights/script.js"
+          viewEndpoint="/_vercel/insights/view"
+          eventEndpoint="/_vercel/insights/event"
         />
       </body>
     </html>

--- a/app/shared.js
+++ b/app/shared.js
@@ -1,6 +1,6 @@
 import {OUTPUT_MARK} from "../runtime/constant.js";
 
-export const BASE_PATH = "/notebook";
+export const BASE_PATH = "";
 
 export function findFirstOutputRange(content) {
   const lines = content.split("\n");

--- a/next.config.js
+++ b/next.config.js
@@ -1,7 +1,24 @@
 /** @type {import('next').NextConfig} */
 const nextConfig = {
-  basePath: "/notebook",
-  assetPrefix: "/notebook",
+  async redirects() {
+    return [
+      {
+        source: "/notebook/:path*",
+        destination: "/:path*",
+        permanent: true,
+      },
+      {
+        source: "/multiples",
+        destination: "https://recho-multiples.vercel.app/",
+        permanent: true,
+      },
+      {
+        source: "/melody",
+        destination: "https://recho-melody.vercel.app/",
+        permanent: true,
+      },
+    ];
+  },
 };
 
 export default nextConfig;

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "A free, open-source, reactive editor for algorithms and ASCII art. It introduces a plain code format for notebooks — echoing output inline as comments for live, in-situ coding with instant feedback.",
   "author": "Recho",
   "license": "ISC",
-  "homepage": "https://recho.dev/notebook",
+  "homepage": "https://recho.dev",
   "repository": {
     "type": "git",
     "url": "https://github.com/recho-dev/notebook.git"


### PR DESCRIPTION
## Summary
- Drops the `/notebook` basePath/assetPrefix so the app is served at the domain root, with a permanent redirect from `/notebook/:path*` to `/:path*` so existing links keep working.
- Cleans up the hardcoded `/notebook` prefixes that only existed to compensate for the old basePath: the `BASE_PATH` constant, the proxied Vercel Analytics endpoints, the examples thumbnail URLs, and doc links.
- Adds permanent redirects for `/melody` → `https://recho-melody.vercel.app/` and `/multiples` → `https://recho-multiples.vercel.app/`.

## Test plan
- `npm run app:build` — confirmed routes now render at `/`, `/docs`, `/examples`, `/works`, etc.
- `npx eslint` on changed files — clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)