### PR TITLE
Never run block detection on an incomplete syntax tree

### DIFF
--- a/editor/blocks/update.ts
+++ b/editor/blocks/update.ts
@@ -1,7 +1,7 @@
 import {Transaction} from "@codemirror/state";
 import {blockRangeLength, findAffectedBlockRange} from "../../lib/blocks.ts";
 import {blocksMatchTree, detectBlocksWithinRange, isMarkLineText, topLevelCoverage} from "../../lib/blocks/detect.ts";
-import {syntaxTree} from "@codemirror/language";
+import {ensureSyntaxTree, syntaxTree, syntaxTreeAvailable} from "@codemirror/language";
 import {BlockMetadata} from "./BlockMetadata.ts";
 
 /**
@@ -11,6 +11,16 @@ import {BlockMetadata} from "./BlockMetadata.ts";
  * reported with `console.error` unconditionally.
  */
 const DEBUG = process.env.NODE_ENV === "test";
+
+/**
+ * How long `updateBlocks` may spend finishing the syntax tree of the new
+ * document. CodeMirror gives the parser only 20ms per transaction, and the
+ * tree a state holds is a snapshot taken when that budget ran out — so under
+ * load, or for a document longer than the initial 3000-character parse
+ * viewport, `syntaxTree(tr.state)` can end far before the document does.
+ * Block detection walks the whole tree, so it must never run on a stump.
+ */
+const PARSE_BUDGET_MS = 50;
 
 /**
  * Give each detected block the identity (id and attributes) of the old block
@@ -84,6 +94,26 @@ function reconcileDetectedBlocks(
 }
 
 /**
+ * Handle a transaction without document changes. Most such transactions are
+ * irrelevant here, but when the syntax tree differs from the start state's,
+ * the background parser has finished a parse that an earlier transaction had
+ * to cut short. If the tree now spans the whole document and the blocks
+ * disagree with it, re-detect everything and reconcile against the current
+ * blocks so identity and attributes survive.
+ */
+function recoverFromCompletedParse(oldBlocks: BlockMetadata[], tr: Transaction): BlockMetadata[] {
+  const tree = syntaxTree(tr.state);
+  if (tree === syntaxTree(tr.startState)) return oldBlocks;
+  if (!syntaxTreeAvailable(tr.state)) return oldBlocks;
+  if (blocksMatchTree(tree, oldBlocks)) return oldBlocks;
+
+  if (DEBUG) console.log("Parse completed with a different tree; re-detecting all blocks");
+  const detected = detectBlocksWithinRange(tree, tr.state.doc, 0, tr.state.doc.length);
+  const mappedOldBlocks = oldBlocks.map((block) => block.map(tr));
+  return reconcileDetectedBlocks(detected, oldBlocks, mappedOldBlocks, tr, new Set());
+}
+
+/**
  * Update block metadata according to the given transaction.
  *
  * The guiding principle: the freshly re-parsed blocks are the ground truth
@@ -98,8 +128,11 @@ function reconcileDetectedBlocks(
  * @param tr the editor transaction
  */
 export function updateBlocks(oldBlocks: BlockMetadata[], tr: Transaction): BlockMetadata[] {
-  // If the transaction does not change the document, then we return early.
-  if (!tr.docChanged) return oldBlocks;
+  // A transaction that leaves the document alone can still carry a new syntax
+  // tree: the background parser dispatches one when it finishes a parse that
+  // did not fit into an earlier transaction's budget. That is the moment to
+  // repair blocks computed from (or kept stale by) an incomplete tree.
+  if (!tr.docChanged) return recoverFromCompletedParse(oldBlocks, tr);
 
   const userEvent = tr.annotation(Transaction.userEvent);
   if (DEBUG) {
@@ -116,6 +149,21 @@ export function updateBlocks(oldBlocks: BlockMetadata[], tr: Transaction): Block
       console.groupEnd();
     }
     return oldBlocks;
+  }
+
+  // Finish parsing the new document before reading its tree. When even the
+  // extra budget is not enough, keep the old blocks — mapped into the new
+  // coordinates so their positions stay right — and let the parser-completion
+  // transaction (see above) redo the structure once the tree is whole.
+  const tree = ensureSyntaxTree(tr.state, tr.state.doc.length, PARSE_BUDGET_MS);
+  if (tree === null) {
+    if (DEBUG) {
+      console.log("Syntax tree is incomplete; keeping mapped old blocks until the parser catches up");
+      console.groupEnd();
+    }
+    // A block whose statement was deleted maps to an empty range; drop it
+    // rather than hand decorations a zero-length block.
+    return oldBlocks.map((block) => block.map(tr)).filter((block) => block.source.from < block.source.to);
   }
 
   /**
@@ -199,7 +247,7 @@ export function updateBlocks(oldBlocks: BlockMetadata[], tr: Transaction): Block
       let extendedFrom = reparseFrom;
       let extendedTo = reparseTo;
 
-      const coverage = topLevelCoverage(syntaxTree(tr.state), reparseFrom, reparseTo);
+      const coverage = topLevelCoverage(tree, reparseFrom, reparseTo);
       if (coverage !== null) {
         extendedFrom = Math.min(extendedFrom, coverage.from);
         extendedTo = Math.max(extendedTo, coverage.to);
@@ -237,7 +285,7 @@ export function updateBlocks(oldBlocks: BlockMetadata[], tr: Transaction): Block
 
     damageRanges.push({from: reparseFrom, to: reparseTo});
 
-    const newBlocks = detectBlocksWithinRange(syntaxTree(tr.state), tr.state.doc, reparseFrom, reparseTo);
+    const newBlocks = detectBlocksWithinRange(tree, tr.state.doc, reparseFrom, reparseTo);
 
     if (DEBUG) console.log("New blocks from reparsed range:", newBlocks);
 
@@ -324,9 +372,9 @@ export function updateBlocks(oldBlocks: BlockMetadata[], tr: Transaction): Block
   // match the tree, fall back to a full re-detect, reconciled against the old
   // blocks so identity and attributes still survive.
   let finalBlocks = newBlocks;
-  if (!blocksMatchTree(syntaxTree(tr.state), newBlocks)) {
+  if (!blocksMatchTree(tree, newBlocks)) {
     if (DEBUG) console.log("Merged blocks do not match the tree; falling back to a full re-detect");
-    const fullDetected = detectBlocksWithinRange(syntaxTree(tr.state), tr.state.doc, 0, tr.state.doc.length);
+    const fullDetected = detectBlocksWithinRange(tree, tr.state.doc, 0, tr.state.doc.length);
     finalBlocks = reconcileDetectedBlocks(fullDetected, oldBlocks, mappedOldBlocks, tr, new Set());
   }
 

--- a/test/blocks/update-partial-tree.spec.ts
+++ b/test/blocks/update-partial-tree.spec.ts
@@ -1,0 +1,136 @@
+import {describe, expect, it, vi, beforeEach, afterEach} from "vitest";
+import {EditorState, Transaction, type ChangeSpec} from "@codemirror/state";
+import {javascript} from "@codemirror/lang-javascript";
+import {ensureSyntaxTree, syntaxTree} from "@codemirror/language";
+import {updateBlocks} from "../../editor/blocks/update.js";
+import {detectBlocksWithinRange} from "../../lib/blocks/detect.js";
+import {type BlockMetadata} from "../../editor/blocks/BlockMetadata.js";
+
+// Lets a test pretend the parser could not finish within updateBlocks' budget.
+const parser = vi.hoisted(() => ({budgetExhausted: false}));
+vi.mock("@codemirror/language", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@codemirror/language")>();
+  return {
+    ...actual,
+    ensureSyntaxTree: (...args: Parameters<typeof actual.ensureSyntaxTree>) =>
+      parser.budgetExhausted ? null : actual.ensureSyntaxTree(...args),
+  };
+});
+
+const DOC = [
+  `const a = 2;`,
+  `const b = a ** 2;`,
+  ``,
+  `echo(add(a, b));`,
+  ``,
+  `function add(a, b) {`,
+  `  return a + b;`,
+  `}`,
+].join("\n");
+
+/**
+ * A document longer than CodeMirror's initial parse viewport (3000 characters)
+ * gets only a partial syntax tree when its state is created, and every later
+ * transaction parses just up to where the previous tree ended — so, without
+ * help, `syntaxTree(state)` stops well short of the document.
+ */
+const LARGE_DOC = Array.from({length: 300}, (_, i) => `const v${i} = ${i};`).join("\n");
+
+function createState(doc: string): EditorState {
+  return EditorState.create({doc, extensions: [javascript()]});
+}
+
+/** Fully parse the state's document and detect all blocks in it. */
+function detectAll(state: EditorState): BlockMetadata[] {
+  const tree = ensureSyntaxTree(state, state.doc.length, 1e9);
+  if (!tree) throw new Error("failed to parse the document");
+  return detectBlocksWithinRange(tree, state.doc, 0, state.doc.length);
+}
+
+/** A user edit, deliberately without forcing a full re-parse afterwards. */
+function edit(state: EditorState, changes: ChangeSpec): Transaction {
+  return state.update({changes, annotations: Transaction.userEvent.of("input.type")});
+}
+
+const ranges = (blocks: BlockMetadata[]) =>
+  blocks.map((b) => [b.source.from, b.source.to, b.output?.from ?? null, b.output?.to ?? null]);
+
+describe("updateBlocks with an incomplete syntax tree", () => {
+  let errorSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    vi.spyOn(console, "group").mockImplementation(() => {});
+    vi.spyOn(console, "groupCollapsed").mockImplementation(() => {});
+    vi.spyOn(console, "groupEnd").mockImplementation(() => {});
+    vi.spyOn(console, "log").mockImplementation(() => {});
+    errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    parser.budgetExhausted = false;
+    vi.restoreAllMocks();
+  });
+
+  it("finishes the parse itself when the state's tree stops short of the document", () => {
+    const state = createState(LARGE_DOC);
+    expect(syntaxTree(state).length).toBeLessThan(state.doc.length);
+    // Ground truth comes from a separate state, so `state` keeps its partial parse.
+    const blocks = detectAll(createState(LARGE_DOC));
+    expect(blocks.length).toBe(300);
+
+    const tr = edit(state, {from: 7, to: 7, insert: "x"});
+    expect(syntaxTree(tr.state).length).toBeLessThan(tr.state.doc.length);
+
+    const updated = updateBlocks(blocks, tr);
+    expect(ranges(updated)).toEqual(ranges(detectAll(tr.state)));
+    expect(updated.map((b) => b.id)).toEqual(blocks.map((b) => b.id));
+    expect(errorSpy).not.toHaveBeenCalled();
+  });
+
+  it("keeps mapped old blocks when the parse cannot finish, then repairs them once it does", () => {
+    const state = createState(LARGE_DOC);
+    const blocks = detectAll(createState(LARGE_DOC));
+
+    // An unterminated template literal in the first statement swallows the
+    // rest of the document, but the parser "cannot finish" within the budget...
+    const tr = edit(state, {from: 7, to: 7, insert: "`"});
+    parser.budgetExhausted = true;
+    const stale = updateBlocks(blocks, tr);
+    parser.budgetExhausted = false;
+
+    // ...so the old structure survives, mapped into the new coordinates.
+    expect(stale.length).toBe(300);
+    expect(stale.map((b) => b.id)).toEqual(blocks.map((b) => b.id));
+    expect(stale[0]!.source).toEqual({from: 0, to: blocks[0]!.source.to + 1});
+    expect(stale[1]!.source).toEqual({from: blocks[1]!.source.from + 1, to: blocks[1]!.source.to + 1});
+
+    // The background parser finishes later and dispatches a transaction that
+    // carries the complete tree but no document changes.
+    ensureSyntaxTree(tr.state, tr.state.doc.length, 1e9);
+    const done = tr.state.update({});
+    expect(done.docChanged).toBe(false);
+    expect(syntaxTree(done.state)).not.toBe(syntaxTree(done.startState));
+    expect(syntaxTree(done.state).length).toBe(done.state.doc.length);
+
+    const repaired = updateBlocks(stale, done);
+    expect(ranges(repaired)).toEqual(ranges(detectAll(done.state)));
+    // The swallow collapsed the structure down to the last statement's end...
+    expect(repaired.length).toBeLessThan(stale.length);
+    expect(repaired[repaired.length - 1]!.source.to).toBe(done.state.doc.length);
+    // ...and every surviving block inherits its identity from one it replaced.
+    const oldIds = new Set(blocks.map((b) => b.id));
+    for (const block of repaired) expect(oldIds.has(block.id)).toBe(true);
+    expect(errorSpy).not.toHaveBeenCalled();
+  });
+
+  it("leaves blocks untouched by transactions that change neither the document nor the tree", () => {
+    const state = createState(DOC);
+    const blocks = detectAll(state);
+    expect(blocks.length).toBe(4);
+
+    const tr = state.update({selection: {anchor: 3}});
+    expect(tr.docChanged).toBe(false);
+    expect(updateBlocks(blocks, tr)).toBe(blocks);
+    expect(errorSpy).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## Problem

`updateBlocks` read `syntaxTree(tr.state)`, which is a snapshot taken when CodeMirror's 20ms per-transaction parse budget (`Work.Apply` in `LanguageState.apply`) ran out. Two situations make that snapshot end before the document does:

- **Load.** If the process is descheduled for >20ms mid-parse, `takeTree()` freezes a truncated tree into the state. This is why the `updateBlocks` fuzz spec from #218 fails nondeterministically in full parallel runs on multi-core machines (2 of 3 runs on a 10-core Mac, never in isolation, never with `--no-file-parallelism`), while CI on 4-vCPU runners stays green. The spec's `edit()` helper does call `ensureSyntaxTree`, but that only completes the mutable parse context; the state's snapshot is a plain property copied at construction and never refreshes.
- **Size.** A document longer than the initial 3000-character parse viewport gets a partial tree at creation, and every later transaction parses only up to where the previous tree ended.

Either way, block detection walked a stump and cut the last block where the parse stopped. In the editor nothing ever repaired it: the background parser's completion transaction carries a new tree but no document changes, and `updateBlocks` returned early on `!tr.docChanged`.

## Fix

- Finish the parse with `ensureSyntaxTree(tr.state, doc.length, 50ms)` before detecting blocks, and use that tree everywhere in `updateBlocks`.
- If even that budget is exhausted, keep the old blocks mapped into the new coordinates (dropping any that mapped to an empty range) instead of computing wrong structure.
- On a transaction without document changes, check whether the tree changed and now covers the whole document; if the blocks disagree with it, re-detect everything and reconcile against the current blocks so ids and attributes survive.

## Tests

`test/blocks/update-partial-tree.spec.ts` uses a 300-statement document (>3000 chars), whose tree is deterministically partial, to cover both paths: the finish-the-parse path, and the fallback-then-repair path (with `ensureSyntaxTree` mocked to return `null` for one call, then a no-change transaction carrying the completed tree). A third test pins the fast path for transactions that change neither document nor tree.

Verification on a 10-core machine: full suite 5/5 green in parallel mode, and 3/3 green under 12 CPU-hog threads; before the fix, main failed 2 of 3 parallel runs and 3 of 3 under load.

🤖 Generated with [Claude Code](https://claude.com/claude-code)