### PR TITLE
Migrate legacy recho.dev localStorage data to www.recho.dev

### DIFF
--- a/app/LegacyDomainMigration.jsx
+++ b/app/LegacyDomainMigration.jsx
@@ -1,0 +1,53 @@
+"use client";
+
+import {useEffect} from "react";
+import {getRawNotebooksPayload, importLegacyNotebooks} from "./api.js";
+
+// recho.dev used to proxy to this app while keeping the browser on the
+// recho.dev origin, so notebooks saved back then live in that origin's
+// localStorage. Now that recho.dev serves this app directly instead of
+// canonicalizing through www.recho.dev at the edge, this component carries
+// those notebooks across the origin boundary by hand: on the legacy host it
+// reads local notebooks and forwards them via a URL fragment (never sent to
+// any server) while redirecting to the canonical host, which imports them on
+// arrival. Remove once recho.dev traffic carrying pre-migration data has
+// faded out.
+
+const LEGACY_HOST = "recho.dev";
+const CANONICAL_HOST = "www.recho.dev";
+const MIGRATE_PARAM = "migrate";
+// Keep well under practical URL length limits; a best-effort migration, not
+// a guarantee for accounts with an unusually large amount of saved content.
+const MAX_PAYLOAD_LENGTH = 20000;
+
+export function LegacyDomainMigration() {
+  useEffect(() => {
+    const {hostname, hash, pathname, search} = window.location;
+
+    if (hostname === LEGACY_HOST) {
+      let fragment = "";
+      try {
+        const payload = getRawNotebooksPayload();
+        if (payload && payload.length <= MAX_PAYLOAD_LENGTH) {
+          fragment = `#${MIGRATE_PARAM}=${encodeURIComponent(payload)}`;
+        }
+      } catch {
+        // localStorage inaccessible (e.g. private browsing) — redirect without it.
+      }
+      window.location.replace(`https://${CANONICAL_HOST}${pathname}${search}${fragment}`);
+      return;
+    }
+
+    if (hostname === CANONICAL_HOST && hash.startsWith(`#${MIGRATE_PARAM}=`)) {
+      try {
+        importLegacyNotebooks(decodeURIComponent(hash.slice(MIGRATE_PARAM.length + 2)));
+      } catch {
+        // Malformed or corrupted payload — nothing to recover, ignore it.
+      } finally {
+        window.history.replaceState(null, "", pathname + search);
+      }
+    }
+  }, []);
+
+  return null;
+}

--- a/app/api.js
+++ b/app/api.js
@@ -95,6 +95,25 @@ export function clearNotebooksFromLocalStorage() {
   localStorage.removeItem(FILE_NAME);
 }
 
+// The two functions below support a one-time migration of notebooks saved
+// under the legacy recho.dev origin (back when it proxied to this app) into
+// the current www.recho.dev origin. See LegacyDomainMigration.jsx. They can
+// be removed once that migration is no longer needed.
+
+export function getRawNotebooksPayload() {
+  return localStorage.getItem(FILE_NAME);
+}
+
+export function importLegacyNotebooks(payload) {
+  if (!payload) return;
+  const incoming = JSON.parse(payload);
+  if (!Array.isArray(incoming) || incoming.length === 0) return;
+  const existing = getNotebooks();
+  const existingIds = new Set(existing.map((notebook) => notebook.id));
+  const merged = [...existing, ...incoming.filter((notebook) => !existingIds.has(notebook.id))];
+  saveNotebooks(merged);
+}
+
 export function getNotebookById(id) {
   const notebooks = getNotebooks();
   return notebooks.find((f) => f.id === id);

--- a/app/layout.jsx
+++ b/app/layout.jsx
@@ -2,6 +2,7 @@ import "./global.css";
 import {Nav} from "./Nav.jsx";
 import {cn} from "./cn.js";
 import {Analytics} from "@vercel/analytics/next";
+import {LegacyDomainMigration} from "./LegacyDomainMigration.jsx";
 
 export const metadata = {
   title: "Recho",
@@ -12,6 +13,7 @@ export default function Layout({children}) {
   return (
     <html lang="en">
       <body className={cn("text-sm")}>
+        <LegacyDomainMigration />
         <Nav />
         <main>{children}</main>
         <Analytics


### PR DESCRIPTION
## Summary
`recho.dev` used to proxy to this app through a rewrite in the separate `landing-page` project, which kept the browser on the `recho.dev` origin the whole time. Now that `recho.dev` is aliased directly to this app, it's a distinct origin from the canonical `www.recho.dev`, so any notebooks people saved under the old setup are invisible on the new one — `localStorage` is strictly origin-scoped and no redirect can read across that boundary.

- Adds `getRawNotebooksPayload`/`importLegacyNotebooks` to `app/api.js`.
- Adds `LegacyDomainMigration.jsx`, wired into the root layout: on `recho.dev` it reads local notebooks and redirects to `www.recho.dev`, carrying them along in a URL fragment (client-side only, never sent to a server); on arrival at `www.recho.dev` it imports/merges them into that origin's storage.

**Requires a Vercel dashboard change to take effect**: `recho.dev` is currently configured to redirect to `www.recho.dev` at the edge (before any app code runs), which would prevent this migration from ever executing. That domain-level redirect on the `recho-notebook` project needs to be turned off so `recho.dev` serves the app directly instead.

## Test plan
- `npm run app:build` and `npx eslint` — clean.
- Manual verification pending the Vercel domain-redirect change above (can't be done from here).

🤖 Generated with [Claude Code](https://claude.com/claude-code)