### PR TITLE
Stop the runtime before re-running from control widgets

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,9 +11,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+      - uses: pnpm/action-setup@v4
+        with:
+          version: 9
       - uses: actions/setup-node@v4
         with:
           node-version: "20"
-      - run: npm install -g pnpm
+          cache: "pnpm"
       - run: pnpm install --frozen-lockfile
       - run: pnpm test

--- a/editor/controls/number.js
+++ b/editor/controls/number.js
@@ -360,7 +360,7 @@ export function number(runtimeRef) {
       annotations: [Transaction.remote.of("control.number")],
     });
 
-    runtimeRef.current.run();
+    runtimeRef.restart();
 
     return true;
   }

--- a/editor/controls/radio.js
+++ b/editor/controls/radio.js
@@ -213,7 +213,7 @@ export function radio(runtimeRef) {
       annotations: [Transaction.remote.of("control.radio")],
     });
 
-    runtimeRef.current.run();
+    runtimeRef.restart();
 
     return true;
   }

--- a/editor/controls/toggle.js
+++ b/editor/controls/toggle.js
@@ -123,9 +123,7 @@ export function toggle(runtimeRef) {
     else if (textAfter.startsWith("true")) change = {from: pos, to: pos + 4, insert: "false"};
     else return false;
     view.dispatch({changes: change, annotations: [Transaction.remote.of("control.toggle")]});
-    setTimeout(() => {
-      runtimeRef.current.run();
-    }, 0);
+    runtimeRef.restart();
     return true;
   }
 

--- a/editor/index.js
+++ b/editor/index.js
@@ -33,7 +33,15 @@ const eslintConfig = {
 export function createEditor(container, options) {
   const {code, onError, extensions = []} = options;
   const dispatcher = d3Dispatch("userInput");
-  const runtimeRef = {current: null};
+  const runtimeRef = {
+    current: null,
+    // Dispose the current runtime (echo.dispose, generators) then re-evaluate.
+    // Defer run so the new runtime starts outside the control's CodeMirror event.
+    restart() {
+      stop();
+      setTimeout(run, 0);
+    },
+  };
 
   const myBasicSetup = Array.from(basicSetup);
   myBasicSetup.splice(2, 0, blockIndicator);
@@ -171,12 +179,8 @@ export function createEditor(container, options) {
     /** @param {boolean} force - Whether to force run the code even if it's already running */
     run: (force = false) => {
       if (runtimeRef.current?.isRunning()) {
-        if (force) {
-          stop();
-          runtimeRef.current.run();
-        } else {
-          return;
-        }
+        if (force) runtimeRef.restart();
+        return;
       }
       run();
     },

--- a/editor/index.js
+++ b/editor/index.js
@@ -33,15 +33,8 @@ const eslintConfig = {
 export function createEditor(container, options) {
   const {code, onError, extensions = []} = options;
   const dispatcher = d3Dispatch("userInput");
-  const runtimeRef = {
-    current: null,
-    // Dispose the current runtime (echo.dispose, generators) then re-evaluate.
-    // Defer run so the new runtime starts outside the control's CodeMirror event.
-    restart() {
-      stop();
-      setTimeout(run, 0);
-    },
-  };
+  const runtimeRef = {current: null, restart};
+  let runTimer = null;
 
   const myBasicSetup = Array.from(basicSetup);
   myBasicSetup.splice(2, 0, blockIndicator);
@@ -157,6 +150,8 @@ export function createEditor(container, options) {
   }
 
   function stop() {
+    clearTimeout(runTimer);
+    runTimer = null;
     runtimeRef.current?.destroy();
     runtimeRef.current = null;
     window.removeEventListener("keydown", onKeyDown);
@@ -166,6 +161,8 @@ export function createEditor(container, options) {
 
   /** Run the runtime. Initialize a new runtime if it doesn't exist. */
   function run() {
+    clearTimeout(runTimer);
+    runTimer = null;
     try {
       if (!runtimeRef.current) initRuntime();
       runtimeRef.current.run();
@@ -175,11 +172,20 @@ export function createEditor(container, options) {
     }
   }
 
+  /** Dispose the current runtime, then run again after the current event. */
+  function restart() {
+    stop();
+    runTimer = setTimeout(run, 0);
+  }
+
   return {
     /** @param {boolean} force - Whether to force run the code even if it's already running */
     run: (force = false) => {
       if (runtimeRef.current?.isRunning()) {
-        if (force) runtimeRef.restart();
+        if (force) {
+          stop();
+          run();
+        }
         return;
       }
       run();
@@ -187,10 +193,7 @@ export function createEditor(container, options) {
     stop,
     on: (event, callback) => dispatcher.on(event, callback),
     destroy: () => {
-      runtimeRef.current?.destroy();
-      window.removeEventListener("keydown", onKeyDown);
-      window.removeEventListener("keyup", onKeyUp);
-      window.removeEventListener("openlink", onOpenLink);
+      stop();
       view.destroy();
     },
   };

--- a/runtime/index.js
+++ b/runtime/index.js
@@ -48,6 +48,7 @@ export function createRuntime(initialCode) {
   let code = initialCode;
   let prevCode = null;
   let isRunning = false;
+  let disposed = false;
 
   // Create button registry for this runtime instance
   const buttonRegistry = new ButtonRegistry();
@@ -77,6 +78,7 @@ export function createRuntime(initialCode) {
   const dispatcher = d3Dispatch("changes", "error");
 
   const refresh = debounce((code) => {
+    if (disposed) return;
     const changes = removeChanges(code);
 
     // Construct an interval tree containing the ranges to be deleted.
@@ -151,6 +153,8 @@ export function createRuntime(initialCode) {
   }
 
   function destroy() {
+    disposed = true;
+    isRunning = false;
     runtime.dispose();
   }
 
@@ -162,7 +166,7 @@ export function createRuntime(initialCode) {
         // Note: A more robust solution would involve applying changes from both
         // output generation and user edits, but this approach provides adequate
         // synchronization for the current implementation.
-        if (isRunning) rerun(code);
+        if (!disposed && isRunning) rerun(code);
       },
       rejected(error) {
         const e = state.syntaxError || error;
@@ -247,18 +251,19 @@ export function createRuntime(initialCode) {
   }
 
   function echo(state, options, ...values) {
-    if (!isRunning) return;
+    if (disposed || !isRunning) return;
     state.values.push({options, values});
     rerun(code);
   }
 
   function clear(state) {
-    if (!isRunning) return;
+    if (disposed || !isRunning) return;
     state.values = [];
     rerun(code);
   }
 
   function rerun(code) {
+    if (disposed) return;
     if (code === prevCode) return refresh(code);
 
     prevCode = code;

--- a/runtime/index.js
+++ b/runtime/index.js
@@ -365,10 +365,16 @@ export function createRuntime(initialCode) {
         __echo__.key = (k) => ((options.key = k), __echo__);
         __echo__.__dispose__ = () => {
           const callbacks = disposes.splice(0);
-          callbacks.forEach((cb) => cb());
+          callbacks.forEach((cb) => {
+            try {
+              cb();
+            } catch (error) {
+              console.error(error);
+            }
+          });
         };
-        // Always dispose when this cell is invalidated, even if the cell
-        // source never mentions `echo` (e.g. visualize(array) in /examples/sorting).
+        // Helpers such as `visualize(array)` may call echo.dispose even when
+        // this cell's source never mentions echo.
         invalidation.then(__echo__.__dispose__);
         return __echo__;
       });

--- a/runtime/index.js
+++ b/runtime/index.js
@@ -344,31 +344,34 @@ export function createRuntime(initialCode) {
       // such as `add(1, 2)`, because the evaluated code may call echo internally.
       let echoVersion = -1;
       const vd = new v.constructor(2, v._module);
-      vd.define(
-        inputs.filter((i) => i !== "echo"),
-        () => {
-          const options = {};
-          const version = v._version; // Capture version on input change.
-          const __echo__ = (value, ...args) => {
-            if (version < echoVersion) throw new Error("stale echo");
-            else if (state.variables[0] !== v) throw new Error("stale echo");
-            else if (version > echoVersion) clear(state);
-            echoVersion = version;
-            echo(state, {...options}, value, ...args);
-            return args.length ? [value, ...args] : value;
-          };
-          const disposes = [];
-          __echo__.clear = () => clear(state);
-          __echo__.set = function (key, value) {
-            state.attributes[key] = value;
-            return this;
-          };
-          __echo__.dispose = (cb) => disposes.push(cb);
-          __echo__.key = (k) => ((options.key = k), __echo__);
-          __echo__.__dispose__ = () => disposes.forEach((cb) => cb());
-          return __echo__;
-        },
-      );
+      vd.define(["invalidation", ...inputs.filter((i) => i !== "echo" && i !== "invalidation")], (invalidation) => {
+        const options = {};
+        const version = v._version; // Capture version on input change.
+        const __echo__ = (value, ...args) => {
+          if (version < echoVersion) throw new Error("stale echo");
+          else if (state.variables[0] !== v) throw new Error("stale echo");
+          else if (version > echoVersion) clear(state);
+          echoVersion = version;
+          echo(state, {...options}, value, ...args);
+          return args.length ? [value, ...args] : value;
+        };
+        const disposes = [];
+        __echo__.clear = () => clear(state);
+        __echo__.set = function (key, value) {
+          state.attributes[key] = value;
+          return this;
+        };
+        __echo__.dispose = (cb) => disposes.push(cb);
+        __echo__.key = (k) => ((options.key = k), __echo__);
+        __echo__.__dispose__ = () => {
+          const callbacks = disposes.splice(0);
+          callbacks.forEach((cb) => cb());
+        };
+        // Always dispose when this cell is invalidated, even if the cell
+        // source never mentions `echo` (e.g. visualize(array) in /examples/sorting).
+        invalidation.then(__echo__.__dispose__);
+        return __echo__;
+      });
       v._shadow.set("echo", vd);
       const newInputs = [...inputs, "echo"];
       state.variables.push(v.define(vid, newInputs, safeEval(body, newInputs, __setEcho__)));

--- a/runtime/index.js
+++ b/runtime/index.js
@@ -169,6 +169,7 @@ export function createRuntime(initialCode) {
         if (!disposed && isRunning) rerun(code);
       },
       rejected(error) {
+        if (disposed) return;
         const e = state.syntaxError || error;
         console.error(e);
         clear(state);

--- a/test/runtime-dispose.spec.js
+++ b/test/runtime-dispose.spec.js
@@ -58,3 +58,41 @@ echo(n);
     expect(globalThis.__rechoUnrelated.disposes).toBe(0);
   });
 });
+
+describe("runtime destroy", () => {
+  let runtime;
+
+  afterEach(() => {
+    runtime?.destroy();
+    runtime = null;
+  });
+
+  it("does not emit changes from a pending refresh after destroy", async () => {
+    let changeCount = 0;
+    runtime = createRuntime("echo(1)");
+    runtime.onChanges(() => {
+      changeCount++;
+    });
+    runtime.run();
+    runtime.destroy();
+    await wait();
+    expect(changeCount).toBe(0);
+  });
+
+  it("does not emit further changes after destroy", async () => {
+    let changeCount = 0;
+    runtime = createRuntime("echo(1)");
+    runtime.onChanges(() => {
+      changeCount++;
+    });
+    runtime.run();
+    await wait();
+    const before = changeCount;
+    expect(before).toBeGreaterThan(0);
+    runtime.destroy();
+    runtime.setIsRunning(true);
+    runtime.run();
+    await wait();
+    expect(changeCount).toBe(before);
+  });
+});

--- a/test/runtime-dispose.spec.js
+++ b/test/runtime-dispose.spec.js
@@ -1,15 +1,22 @@
 import {it, expect, describe, afterEach} from "vitest";
 import {createRuntime} from "../runtime/index.js";
 
+const wait = (ms = 150) => new Promise((resolve) => setTimeout(resolve, ms));
+
 describe("echo.dispose on invalidation", () => {
-  afterEach(() => {
+  let runtime;
+
+  afterEach(async () => {
+    runtime?.destroy();
+    runtime = null;
+    await wait(0);
     delete globalThis.__rechoEchoDispose;
     delete globalThis.__rechoUnrelated;
   });
 
   it("runs echo.dispose when a caller that never mentions echo is invalidated", async () => {
     globalThis.__rechoEchoDispose = {starts: 0, disposes: 0};
-    const runtime = createRuntime(`const [n, setN] = recho.state(0);
+    runtime = createRuntime(`const [n, setN] = recho.state(0);
 recho.button("Go", () => setN(n + 1));
 go(n);
 function go(n) {
@@ -21,21 +28,19 @@ function go(n) {
 `);
     runtime.onChanges(() => {});
     runtime.run();
-    await new Promise((resolve) => setTimeout(resolve, 150));
+    await wait();
     expect(globalThis.__rechoEchoDispose.starts).toBe(1);
     expect(globalThis.__rechoEchoDispose.disposes).toBe(0);
 
     runtime.buttonRegistry.executeCallback("Go");
-    await new Promise((resolve) => setTimeout(resolve, 150));
+    await wait();
     expect(globalThis.__rechoEchoDispose.disposes).toBe(1);
     expect(globalThis.__rechoEchoDispose.starts).toBe(2);
-
-    runtime.destroy();
   });
 
   it("does not dispose unrelated cells when a button updates state", async () => {
     globalThis.__rechoUnrelated = {disposes: 0};
-    const runtime = createRuntime(`const [n, setN] = recho.state(0);
+    runtime = createRuntime(`const [n, setN] = recho.state(0);
 recho.button("Go", () => setN(n + 1));
 echo(n);
 {
@@ -46,12 +51,10 @@ echo(n);
 `);
     runtime.onChanges(() => {});
     runtime.run();
-    await new Promise((resolve) => setTimeout(resolve, 150));
+    await wait();
 
     runtime.buttonRegistry.executeCallback("Go");
-    await new Promise((resolve) => setTimeout(resolve, 150));
+    await wait();
     expect(globalThis.__rechoUnrelated.disposes).toBe(0);
-
-    runtime.destroy();
   });
 });

--- a/test/runtime-dispose.spec.js
+++ b/test/runtime-dispose.spec.js
@@ -1,0 +1,57 @@
+import {it, expect, describe, afterEach} from "vitest";
+import {createRuntime} from "../runtime/index.js";
+
+describe("echo.dispose on invalidation", () => {
+  afterEach(() => {
+    delete globalThis.__rechoEchoDispose;
+    delete globalThis.__rechoUnrelated;
+  });
+
+  it("runs echo.dispose when a caller that never mentions echo is invalidated", async () => {
+    globalThis.__rechoEchoDispose = {starts: 0, disposes: 0};
+    const runtime = createRuntime(`const [n, setN] = recho.state(0);
+recho.button("Go", () => setN(n + 1));
+go(n);
+function go(n) {
+  globalThis.__rechoEchoDispose.starts++;
+  echo.dispose(() => {
+    globalThis.__rechoEchoDispose.disposes++;
+  });
+}
+`);
+    runtime.onChanges(() => {});
+    runtime.run();
+    await new Promise((resolve) => setTimeout(resolve, 150));
+    expect(globalThis.__rechoEchoDispose.starts).toBe(1);
+    expect(globalThis.__rechoEchoDispose.disposes).toBe(0);
+
+    runtime.buttonRegistry.executeCallback("Go");
+    await new Promise((resolve) => setTimeout(resolve, 150));
+    expect(globalThis.__rechoEchoDispose.disposes).toBe(1);
+    expect(globalThis.__rechoEchoDispose.starts).toBe(2);
+
+    runtime.destroy();
+  });
+
+  it("does not dispose unrelated cells when a button updates state", async () => {
+    globalThis.__rechoUnrelated = {disposes: 0};
+    const runtime = createRuntime(`const [n, setN] = recho.state(0);
+recho.button("Go", () => setN(n + 1));
+echo(n);
+{
+  echo.dispose(() => {
+    globalThis.__rechoUnrelated.disposes++;
+  });
+}
+`);
+    runtime.onChanges(() => {});
+    runtime.run();
+    await new Promise((resolve) => setTimeout(resolve, 150));
+
+    runtime.buttonRegistry.executeCallback("Go");
+    await new Promise((resolve) => setTimeout(resolve, 150));
+    expect(globalThis.__rechoUnrelated.disposes).toBe(0);
+
+    runtime.destroy();
+  });
+});


### PR DESCRIPTION
## Summary
- Radio, toggle, and number widgets now stop and dispose the current runtime before evaluating the new value, so `echo.dispose` and generators actually tear down.
- Ignore stale `echo` / `refresh` work after destroy so leftover intervals cannot keep updating alongside the new run.
- `recho.button` is unchanged; it still only runs its callback.

## Test plan
- [x] Open a notebook with a control plus a live resource (e.g. `recho.radio` + `setInterval` + `echo.dispose`, or animation-experiments with `recho.number` + `recho.interval`).
- [x] Click the radio / toggle / number: the previous timer should stop (no double-speed echo, no stacked intervals).
- [x] Type in the editor then click Play: still incremental; widget clicks should not mark the notebook dirty / need rerun.
- [x] Click `recho.button`: callback still runs without restarting the runtime.


Made with [Cursor](https://cursor.com)